### PR TITLE
Add orientation reading support

### DIFF
--- a/DDC.h
+++ b/DDC.h
@@ -45,6 +45,7 @@
 #define RED_BLACK_LEVEL 0x6C
 #define GREEN_BLACK_LEVEL 0x6E
 #define BLUE_BLACK_LEVEL 0x70
+#define ORIENTATION 0xAA
 #define AUDIO_MUTE 0x8D
 #define SETTINGS 0xB0                  //unsure on this one
 #define ON_SCREEN_DISPLAY 0xCA

--- a/ddcctl.m
+++ b/ddcctl.m
@@ -90,6 +90,7 @@ int main(int argc, const char * argv[])
                                    @"i": @INPUT_SOURCE, //pg85
                                    @"m": @AUDIO_MUTE,
                                    @"v": @AUDIO_SPEAKER_VOLUME, //pg94
+                                   @"o": @ORIENTATION,
                                    }; //should test against http://www.entechtaiwan.com/lib/softmccs.shtm
 
         NSUInteger command_interval = [[NSUserDefaults standardUserDefaults] integerForKey:@"w"];
@@ -170,6 +171,7 @@ int main(int argc, const char * argv[])
 	-v <1-254> [speaker volume]\n\
 	-i <1-12> [select input source]\n\
 	-p <1|2-5> [power on | standby/off]\n\
+    -o [read-only orientation]\n\
 \
 ----- Setting grammar -----\n\
  -X ? (queries setting X)\n\


### PR DESCRIPTION
Only supported on some monitors, but it seems to work on BenQ ones.