### PR TITLE
add script to track primary display brightness

### DIFF
--- a/track_primary_brightness.sh
+++ b/track_primary_brightness.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+function get_primary_brightness() {
+  brightness_string=$(ioreg -c AppleBacklightDisplay | grep -o '"brightness"=[^}]*}')
+
+  # this should be something like `"brightness"={"min"=0,"max"=65535,"value"=4108}`, pull out the #'s
+  read min max val <<< $(echo "$brightness_string" | egrep -o '[0-9]+' | tr '\n' ' ')
+
+  brightness=$(bc <<< "scale=2; 100 * ($val / $max)" | cut -d'.' -f1)
+  echo $brightness
+}
+
+function set_external_brightness() {
+  echo "Setting external brightness to: $1"
+
+  for i in $(seq $(./ddcctl 2>&1 | grep 'found [0-9]' | grep -o '[0-9]')); do
+    ./ddcctl -d $i -b $1 2>&1 > /dev/null
+  done
+}
+
+last_brightness=-1
+while true; do
+  brightness=$(get_primary_brightness)
+  if [ $last_brightness != $brightness ]; then
+    last_brightness=$brightness
+    echo "Updating brightness to $brightness"
+    set_external_brightness $brightness
+  fi
+  sleep 0.1
+done


### PR DESCRIPTION
This tool was a super exciting discovery -- thanks for writing it!

I threw together a quick script to have my external monitor(s) track the primary display, which is controlled automatically by OS X. There wasn't an immediately obvious mechanism other than polling for this, but I found 100ms was responsive enough that the external displays moved in clean steps.

I'm not sure I'd pay the 10Hz process wakeup penalty on my laptop, but nice for the work desktop.