### PR TITLE
Update documentation for input sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adjust your external monitors' built-in controls from the OSX shell:
 * contrast  
 
 And *possibly* (if your monitor firmware is well implemented):  
-* input source  
+* input source
 * built-in speaker volume  
 * on/off/standby
 * rgb colors
@@ -26,3 +26,28 @@ Usage
 Run `ddcctl -h` for some options.  
 [ddcctl.sh](/ddcctl.sh) is a script I use to control two PC monitors plugged into my Mac Mini.  
 You can point Alfred, ControlPlane, or Karabiner at it to quickly switch presets.  
+
+Input Sources
+----
+When setting input source, refer to the table below to determine which value to use. For example, to set your first display to HDMI: `ddcctl -d 1 -i 17`
+
+| Input Source | Value        |
+| ------------- |-------------|
+| VGA-1 | 1 |
+| VGA-2 | 2 |
+| DVI-1 | 3 |
+| DVI-2 | 4 |
+| Composite video 1 | 5 |
+| Composite video 2 | 6 |
+| S-Video-1 | 7 |
+| S-Video-2 | 8 |
+| Tuner-1 | 9 |
+| Tuner-2 | 10 |
+| Tuner-3 | 11 |
+| Component video (YPrPb/YCrCb) 1 | 12 |
+| Component video (YPrPb/YCrCb) 2 | 13 |
+| Component video (YPrPb/YCrCb) 3 | 14 |
+| DisplayPort-1 | 15 |
+| DisplayPort-2 | 16 |
+| HDMI-1 | 17 |
+| HDMI-2 | 18 |

--- a/ddcctl.m
+++ b/ddcctl.m
@@ -182,7 +182,7 @@ int main(int argc, const char * argv[])
         @"----- Settings that don\'t always work -----\n"
         @"\t-m <1|2>   [mute speaker OFF/ON]\n"
         @"\t-v <1-254> [speaker volume]\n"
-        @"\t-i <1-12>  [select input source]\n"
+        @"\t-i <1-18>  [select input source]\n"
         @"\t-p <1|2-5> [power on | standby/off]\n"
         @"\t-o         [read-only orientation]\n"
         @"\n"


### PR DESCRIPTION
Thanks @kfix for this nifty command line utility. My primary use case was to switch input (from Mac to Mac and vice versa) and had to do a bit of digging to understand how the input source values work. Updated the documentation with the mapping in case it's useful to others in the future.

(source: https://milek7.pl/ddcbacklight/mccs.pdf - page 81) 