### PR TITLE
Fix signed/unsigned compare, issue #53

### DIFF
--- a/DDC.c
+++ b/DDC.c
@@ -77,9 +77,9 @@ static io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID
             CFNumberGetValue(serialNumberRef, kCFNumberCFIndexType, &serialNumber);
 
         // compare IOreg's metadata to CGDisplay's metadata to infer if the IOReg's I2C monitor is the display for the given NSScreen.displayID
-        if (CGDisplayVendorNumber(displayID) != vendorID  ||
-            CGDisplayModelNumber(displayID)  != productID ||
-            CGDisplaySerialNumber(displayID) != serialNumber) // SN is zero in lots of cases, so duplicate-monitors can confuse us :-/
+        if (CGDisplayVendorNumber(displayID) != (UInt32)vendorID  ||
+            CGDisplayModelNumber(displayID)  != (UInt32)productID ||
+            CGDisplaySerialNumber(displayID) != (UInt32)serialNumber) // SN is zero in lots of cases, so duplicate-monitors can confuse us :-/
         {
             CFRelease(info);
             continue;


### PR DESCRIPTION
From https://github.com/kfix/ddcctl/issues/53#issuecomment-525921778:

"On line 82 of DDC.c of the current project master,

Do this:
CGDisplaySerialNumber(displayID) != (UInt32)serialNumber
Instead of:
CGDisplaySerialNumber(displayID) != serialNumber

Compile with 'make' and try it. It solved this problem for my Acer UT220hql, which now works perfectly. Tested with MacBook Pro Late 2013 over HDMI[, and now also a Mac Mini 2018].

Technically you'd want to do this to lines 80 and 81, as well, as the CGDisplay...Number functions return uint32_t. CFIndex, by converse, is a signed int. At least on my monitor, the MSB of the serial number is a 1, so the serial number comparison fails."

It appears this may allow a number of monitors to suddenly work fine now, too, looking at further comments on the issue.