### PR TITLE
refactor IOFramebuffer discovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_REPORT.md
@@ -22,19 +22,7 @@ I _will_ close reports about these issues out-of-hand:
 ### __MY HACKINTOSH <whatever>__:  
 You're on your own with Hackintoshes.  
 
-### __I HAVE TWO IDENTICAL MONITORS AND ONE DOESN'T WORK__:  
-This is already known: #17  
-
-No patch has been submitted to resolve this, but the essential facts have  
-been gathered to work from.  
-
-Any suggestion to revert the master branch to an obsolete version  
-to work-around this will be rejected.  
-
-Release and mantain your own fork if this bothers you.  
-I do not work for you and will not be providing backports for your convienience.  
-
-### __YOUR PC MONITOR MAY SUCK AT DDC__  
+### __YOUR MONITOR MAY NOT CORRECTLY SUPPORT MUCH OF DDC__  
 The DDC standard is very loosely implemented by monitor manufacturers beyond sleeping the display.  
 * This is because Windows doesn't use brightness sensors to dim screens like OSX does —via USB, not DDC!
 * Adjusting brightness, contrast, and super-awesome-multimedia-frobber-mode may not be possible.  

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 #!/bin/make -f
 
-CCFLAGS ?= -Wno-unused-variable
-
 ## Reply Transaction Type
 ## uncomment one only one
 ## comment both to use automatic detection

--- a/src/DDC.c
+++ b/src/DDC.c
@@ -27,8 +27,7 @@ _Static_assert (0, "must build with `make (amd|intel|nvidia)`");
 
 /*
 
- Iterate IOreg's device tree to find the IOFramebuffer mach service port that corresponds to a given CGDisplayID
- replaces CGDisplayIOServicePort: https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGDisplayIOServicePort
+ Iterate IOreg's device tree to find the IOFramebuffer mach service port that corresponds to a given CGDisplayID && IOReg path
  based on: https://github.com/glfw/glfw/pull/192/files
  */
 io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID, CFStringRef displayLocation)

--- a/src/DDC.c
+++ b/src/DDC.c
@@ -31,7 +31,7 @@ _Static_assert (0, "must build with `make (amd|intel|nvidia)`");
  replaces CGDisplayIOServicePort: https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGDisplayIOServicePort
  based on: https://github.com/glfw/glfw/pull/192/files
  */
-static io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID)
+io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID, CFStringRef displayLocation)
 {
     io_iterator_t iter;
     io_service_t serv, servicePort = 0;
@@ -45,24 +45,39 @@ static io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID
     while ((serv = IOIteratorNext(iter)) != MACH_PORT_NULL)
     {
         CFDictionaryRef info;
-        io_name_t	name;
-        CFIndex vendorID = 0, productID = 0, serialNumber = 0, dependID = 0, dependIndex = 0;
-        CFNumberRef vendorIDRef, productIDRef, serialNumberRef, dependIDRef, dependIndexRef;
-#ifdef DEBUG
+        CFIndex vendorID = 0, productID = 0, serialNumber = 0;
+        CFNumberRef vendorIDRef, productIDRef, serialNumberRef;
         CFStringRef location = CFSTR("");
+#ifdef DEBUG
+        CFIndex     dependID = 0, dependIndex = 0;
+        CFNumberRef dependIDRef, dependIndexRef;
+        io_name_t   name;
         CFStringRef serial = CFSTR("");
-#endif
-        Boolean success = 0;
 
         // get metadata from IOreg node
         IORegistryEntryGetName(serv, name);
         info = IODisplayCreateInfoDictionary(serv, kIODisplayOnlyPreferredName);
 
-#ifdef DEBUG
+        CFStringRef ioRegPath = IORegistryEntryCopyPath(serv,  kIOServicePlane);
+        // just location/../../ (-- /display0/AppleDisplay)
+
+        // https://stackoverflow.com/a/48450870/3878712
+        CFUUIDRef uuid = CGDisplayCreateUUIDFromDisplayID(displayID);
+        CFStringRef uuidStr = CFUUIDCreateString(NULL, uuid);
+#endif
+        Boolean success = 0;
+
+        //IORegistryEntryCopyFromPath
+        //IORegistryEntryGetProperty(serv, propName, buf, sz)
+
+        info = IODisplayCreateInfoDictionary(serv, kIODisplayOnlyPreferredName); // kIODisplayMatchingInfo
+        // IODisplayMatchDictionaries(mat, mat, NULL)
+
         /* When assigning a display ID, Quartz considers the following parameters:Vendor, Model, Serial Number and Position in the I/O Kit registry */
         // http://opensource.apple.com//source/IOGraphics/IOGraphics-179.2/IOGraphicsFamily/IOKit/graphics/IOGraphicsTypes.h
         CFStringRef locationRef = CFDictionaryGetValue(info, CFSTR(kIODisplayLocationKey));
         if (locationRef) location = CFStringCreateCopy(NULL, locationRef);
+#ifdef DEBUG
         CFStringRef serialRef = CFDictionaryGetValue(info, CFSTR(kDisplaySerialString));
         if (serialRef) serial = CFStringCreateCopy(NULL, serialRef);
 
@@ -89,12 +104,22 @@ static io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID
             CFRelease(info);
             continue;
         }
-        // if (framebuffer.hasDDCConnect(0)) // https://developer.apple.com/reference/kernel/ioframebuffer/1813510-hasddcconnect?language=objc
         // kAppleDisplayTypeKey -- if this is an Apple display, can use IODisplay func to change brightness: http://stackoverflow.com/a/32691700/3878712
 
         if (CFDictionaryGetValueIfPresent(info, CFSTR(kDisplaySerialNumber), (const void**)&serialNumberRef))
             CFNumberGetValue(serialNumberRef, kCFNumberCFIndexType, &serialNumber);
-
+#ifdef DEBUG
+        printf("I: Attempting match for %s's IODisplayPort @ %s...\n",
+            CFStringGetCStringPtr(uuidStr, kCFStringEncodingUTF8), CFStringGetCStringPtr(location, kCFStringEncodingUTF8));
+#endif
+        if (displayLocation) {
+            // we were provided with a specific ioreg location we suspect the targeted framebuffer to be attached to...
+            if (!CFStringHasPrefix(location, displayLocation)) {
+                // this framebuffer doesn't reside within the provided location
+                CFRelease(info);
+                continue;
+            }
+        }
         // compare IOreg's metadata to CGDisplay's metadata to infer if the IOReg's I2C monitor is the display for the given NSScreen.displayID
         if (CGDisplayVendorNumber(displayID) != (UInt32)vendorID  ||
             CGDisplayModelNumber(displayID)  != (UInt32)productID ||
@@ -112,6 +137,7 @@ static io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID
         // considering this IOFramebuffer as the match for the CGDisplay, dump out its information
         // compare with `make displaylist`
         printf("\nFramebuffer: %s\n", name);
+        printf("%s\n", CFStringGetCStringPtr(ioRegPath, kCFStringEncodingUTF8));
         printf("%s\n", CFStringGetCStringPtr(location, kCFStringEncodingUTF8));
         printf("VN:%ld PN:%ld SN:%ld", vendorID, productID, serialNumber);
         printf(" UN:%d", CGDisplayUnitNumber(displayID));
@@ -130,50 +156,45 @@ static io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID
     return servicePort;
 }
 
-dispatch_semaphore_t DisplayQueue(CGDirectDisplayID displayID) {
+dispatch_semaphore_t I2CRequestQueue(io_service_t i2c_device_id) {
     static UInt64 queueCount = 0;
-    static struct DDCQueue {CGDirectDisplayID id; dispatch_semaphore_t queue;} *queues = NULL;
+    static struct ReqQueue {uint32_t id; dispatch_semaphore_t queue;} *queues = NULL;
     dispatch_semaphore_t queue = NULL;
     if (!queues)
         queues = calloc(50, sizeof(*queues)); //FIXME: specify
     UInt64 i = 0;
     while (i < queueCount)
-        if (queues[i].id == displayID)
+        if (queues[i].id == i2c_device_id)
             break;
         else
             i++;
-    if (queues[i].id == displayID)
+    if (queues[i].id == i2c_device_id)
         queue = queues[i].queue;
     else
-        queues[queueCount++] = (struct DDCQueue){displayID, (queue = dispatch_semaphore_create(1))};
+        queues[queueCount++] = (struct ReqQueue){i2c_device_id, (queue = dispatch_semaphore_create(1))};
     return queue;
 }
 
-bool DisplayRequest(CGDirectDisplayID displayID, IOI2CRequest *request) {
-    dispatch_semaphore_t queue = DisplayQueue(displayID);
+bool FramebufferI2CRequest(io_service_t framebuffer, IOI2CRequest *request) {
+    dispatch_semaphore_t queue = I2CRequestQueue(framebuffer);
     dispatch_semaphore_wait(queue, DISPATCH_TIME_FOREVER);
     bool result = false;
-    io_service_t framebuffer; // https://developer.apple.com/reference/kernel/ioframebuffer
-    //if ((framebuffer = CGDisplayIOServicePort(displayID))) { // Deprecated in OSX 10.9
-    if ((framebuffer = IOFramebufferPortFromCGDisplayID(displayID))) {
-        IOItemCount busCount;
-        if (IOFBGetI2CInterfaceCount(framebuffer, &busCount) == KERN_SUCCESS) {
-            IOOptionBits bus = 0;
-            while (bus < busCount) {
-                io_service_t interface;
-                if (IOFBCopyI2CInterfaceForBus(framebuffer, bus++, &interface) != KERN_SUCCESS)
-                    continue;
+    IOItemCount busCount;
+    if (IOFBGetI2CInterfaceCount(framebuffer, &busCount) == KERN_SUCCESS) {
+        IOOptionBits bus = 0;
+        while (bus < busCount) {
+            io_service_t interface;
+            if (IOFBCopyI2CInterfaceForBus(framebuffer, bus++, &interface) != KERN_SUCCESS)
+                continue;
 
-                IOI2CConnectRef connect;
-                if (IOI2CInterfaceOpen(interface, kNilOptions, &connect) == KERN_SUCCESS) {
-                    result = (IOI2CSendRequest(connect, kNilOptions, request) == KERN_SUCCESS);
-                    IOI2CInterfaceClose(connect, kNilOptions);
-                }
-                IOObjectRelease(interface);
-                if (result) break;
+            IOI2CConnectRef connect;
+            if (IOI2CInterfaceOpen(interface, kNilOptions, &connect) == KERN_SUCCESS) {
+                result = (IOI2CSendRequest(connect, kNilOptions, request) == KERN_SUCCESS);
+                IOI2CInterfaceClose(connect, kNilOptions);
             }
+            IOObjectRelease(interface);
+            if (result) break;
         }
-        IOObjectRelease(framebuffer);
     }
     if (request->replyTransactionType == kIOI2CNoTransactionType)
         usleep(20000);
@@ -181,7 +202,7 @@ bool DisplayRequest(CGDirectDisplayID displayID, IOI2CRequest *request) {
     return result && request->result == KERN_SUCCESS;
 }
 
-bool DDCWrite(CGDirectDisplayID displayID, struct DDCWriteCommand *write) {
+bool DDCWrite(io_service_t framebuffer, struct DDCWriteCommand *write) {
     IOI2CRequest    request;
     UInt8           data[128];
 
@@ -205,11 +226,11 @@ bool DDCWrite(CGDirectDisplayID displayID, struct DDCWriteCommand *write) {
     request.replyTransactionType            = kIOI2CNoTransactionType;
     request.replyBytes                      = 0;
 
-    bool result = DisplayRequest(displayID, &request);
+    bool result = FramebufferI2CRequest(framebuffer, &request);
     return result;
 }
 
-bool DDCRead(CGDirectDisplayID displayID, struct DDCReadCommand *read) {
+bool DDCRead(io_service_t framebuffer, struct DDCReadCommand *read) {
     IOI2CRequest request;
     UInt8 reply_data[11] = {};
     bool result = false;
@@ -249,7 +270,7 @@ bool DDCRead(CGDirectDisplayID displayID, struct DDCReadCommand *read) {
         request.replyBuffer = (vm_address_t) reply_data;
         request.replyBytes = sizeof(reply_data);
 
-        result = DisplayRequest(displayID, &request);
+        result = FramebufferI2CRequest(framebuffer, &request);
         result = (result && reply_data[0] == request.sendAddress && reply_data[2] == 0x2 && reply_data[4] == read->control_id && reply_data[10] == (request.replyAddress ^ request.replySubAddress ^ reply_data[1] ^ reply_data[2] ^ reply_data[3] ^ reply_data[4] ^ reply_data[5] ^ reply_data[6] ^ reply_data[7] ^ reply_data[8] ^ reply_data[9]));
 
         if (result) { // checksum is ok
@@ -388,7 +409,7 @@ UInt32 SupportedTransactionType() {
 }
 
 
-bool EDIDTest(CGDirectDisplayID displayID, struct EDID *edid) {
+bool EDIDTest(io_service_t framebuffer, struct EDID *edid) {
     IOI2CRequest request = {};
 /*! from https://opensource.apple.com/source/IOGraphics/IOGraphics-513.1/IOGraphicsFamily/IOKit/i2c/IOI2CInterface.h.auto.html
  *  not in https://developer.apple.com/reference/kernel/1659924-ioi2cinterface.h/ioi2crequest?changes=latest_beta&language=objc
@@ -433,7 +454,7 @@ bool EDIDTest(CGDirectDisplayID displayID, struct EDID *edid) {
     request.replyTransactionType = kIOI2CSimpleTransactionType;
     request.replyBuffer = (vm_address_t) data;
     request.replyBytes = sizeof(data);
-    if (!DisplayRequest(displayID, &request)) return false;
+    if (!FramebufferI2CRequest(framebuffer, &request)) return false;
     if (edid) memcpy(edid, &data, 128);
     UInt32 i = 0;
     UInt8 sum = 0;

--- a/src/DDC.c
+++ b/src/DDC.c
@@ -66,11 +66,7 @@ io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID, CFStr
 #endif
         Boolean success = 0;
 
-        //IORegistryEntryCopyFromPath
-        //IORegistryEntryGetProperty(serv, propName, buf, sz)
-
         info = IODisplayCreateInfoDictionary(serv, kIODisplayOnlyPreferredName); // kIODisplayMatchingInfo
-        // IODisplayMatchDictionaries(mat, mat, NULL)
 
         /* When assigning a display ID, Quartz considers the following parameters:Vendor, Model, Serial Number and Position in the I/O Kit registry */
         // http://opensource.apple.com//source/IOGraphics/IOGraphics-179.2/IOGraphicsFamily/IOKit/graphics/IOGraphicsTypes.h

--- a/src/DDC.h
+++ b/src/DDC.h
@@ -234,8 +234,9 @@ struct EDID {
     UInt8 checksum : 8;
 };
 
-bool DDCWrite(CGDirectDisplayID displayID, struct DDCWriteCommand *write);
-bool DDCRead(CGDirectDisplayID displayID, struct DDCReadCommand *read);
-bool EDIDTest(CGDirectDisplayID displayID, struct EDID *edid);
+bool DDCWrite(io_service_t framebuffer, struct DDCWriteCommand *write);
+bool DDCRead(io_service_t framebuffer, struct DDCReadCommand *read);
+bool EDIDTest(io_service_t framebuffer, struct EDID *edid);
 UInt32 SupportedTransactionType(void);
+io_service_t IOFramebufferPortFromCGDisplayID(CGDirectDisplayID displayID, CFStringRef displayLocation);
 #endif

--- a/src/ddcctl.m
+++ b/src/ddcctl.m
@@ -403,10 +403,8 @@ int main(int argc, const char * argv[])
         NSString *devLoc = getDisplayDeviceLocation(cdisplay);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        if (!devLoc && CGDisplayIOServicePort != NULL) {
-            // fuzzy-matching discovery of the device location failed, so try using the
-            // legacy API call to get the IOFB's service port
-            // this API was deprecated after macOS 10.9:
+        if (CGDisplayIOServicePort != NULL) {
+            // legacy API call to get the IOFB's service port, was deprecated after macOS 10.9:
             //     https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGDisplayIOServicePort
             framebuffer = CGDisplayIOServicePort(cdisplay);
 #pragma clang diagnostic pop

--- a/src/ddcctl.m
+++ b/src/ddcctl.m
@@ -29,6 +29,7 @@ int blacklistedDeviceWithNumber;
 bool useOsd;
 #endif
 
+extern io_service_t CGDisplayIOServicePort(CGDirectDisplayID display) __attribute__((weak_import));
 
 NSString *EDIDString(char *string)
 {
@@ -395,13 +396,13 @@ int main(int argc, const char * argv[])
         // find & grab the IOFramebuffer for the display, the IOFB is where DDC/I2C commands are sent
         io_service_t framebuffer = 0;
         NSString *devLoc = getDisplayDeviceLocation(cdisplay);
-        if (!devLoc) {
-            // fuzzy-matching discovery of the device location failed, so try using the
-            // legacy API call to get the IOFB's service port
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-           // this API was deprecated after macOS 10.9:
-           //     https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGDisplayIOServicePort
+        if (!devLoc && CGDisplayIOServicePort != NULL) {
+            // fuzzy-matching discovery of the device location failed, so try using the
+            // legacy API call to get the IOFB's service port
+            // this API was deprecated after macOS 10.9:
+            //     https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGDisplayIOServicePort
             framebuffer = CGDisplayIOServicePort(cdisplay);
 #pragma clang diagnostic pop
         }

--- a/src/ddcctl.m
+++ b/src/ddcctl.m
@@ -55,14 +55,14 @@ uint getControl(CGDirectDisplayID cdisplay, uint control_id)
 }
 
 /* Set new value for control from display */
-void setControl(CGDirectDisplayID cdisplay, uint control_id, uint new_value)
+void setControl(io_service_t framebuffer, uint control_id, uint new_value)
 {
     struct DDCWriteCommand command;
     command.control_id = control_id;
     command.new_value = new_value;
 
     MyLog(@"D: setting VCP control #%u => %u", command.control_id, command.new_value);
-    if (!DDCWrite(cdisplay, &command)){
+    if (!DDCWrite(framebuffer, &command)){
         MyLog(@"E: Failed to send DDC command!");
     }
 #ifdef OSD
@@ -91,7 +91,7 @@ void setControl(CGDirectDisplayID cdisplay, uint control_id, uint new_value)
 }
 
 /* Get current value to Set relative value for control from display */
-void getSetControl(CGDirectDisplayID cdisplay, uint control_id, NSString *new_value, NSString *operator)
+void getSetControl(io_service_t framebuffer, uint control_id, NSString *new_value, NSString *operator)
 {
     struct DDCReadCommand command;
     command.control_id = control_id;
@@ -101,7 +101,7 @@ void getSetControl(CGDirectDisplayID cdisplay, uint control_id, NSString *new_va
     // read
     MyLog(@"D: querying VCP control: #%u =?", command.control_id);
 
-    if (!DDCRead(cdisplay, &command)) {
+    if (!DDCRead(framebuffer, &command)) {
         MyLog(@"E: DDC send command failed!");
         MyLog(@"E: VCP control #%u (0x%02hhx) = current: %u, max: %u", command.control_id, command.control_id, command.current_value, command.max_value);
     } else {
@@ -114,10 +114,9 @@ void getSetControl(CGDirectDisplayID cdisplay, uint control_id, NSString *new_va
     NSNumber *set_value = [exp expressionValueWithObject:nil context:nil];
 
     // validate and write
-
     int clamped_value = MIN(MAX(set_value.intValue, 0), command.max_value);
     MyLog(@"D: relative setting: %@ = %d (clamped to 0, %d)", formula, clamped_value, command.max_value);
-    setControl(cdisplay, control_id, (uint) clamped_value);
+    setControl(framebuffer, control_id, (uint) clamped_value);
 }
 
 /* Main function */
@@ -134,20 +133,25 @@ int main(int argc, const char * argv[])
             if ([description objectForKey:@"NSDeviceIsScreen"]) {
                 CGDirectDisplayID screenNumber = [[description objectForKey:@"NSScreenNumber"] unsignedIntValue];
                 if (CGDisplayIsBuiltin(screenNumber)) continue; // ignore MacBook screens because the lid can be closed and they don't use DDC.
+                // https://stackoverflow.com/a/48450870/3878712
+                CFUUIDRef screenUUID = CGDisplayCreateUUIDFromDisplayID(screenNumber);
+                CFStringRef screenUUIDstr = CFUUIDCreateString(NULL, screenUUID);
                 [_displayIDs addPointer:(void *)(UInt64)screenNumber];
                 NSSize displayPixelSize = [[description objectForKey:NSDeviceSize] sizeValue];
                 CGSize displayPhysicalSize = CGDisplayScreenSize(screenNumber); // dspPhySz only valid if EDID present!
                 float displayScale = [screen backingScaleFactor];
                 double rotation = CGDisplayRotation(screenNumber);
                 if (displayScale > 1) {
-                    MyLog(@"D: NSScreen #%u (%.0fx%.0f %g°) HiDPI",
+                    MyLog(@"D: CGDisplay %@ dispID(#%u) (%.0fx%.0f %g°) HiDPI",
+                          screenUUIDstr,
                           screenNumber,
                           displayPixelSize.width,
                           displayPixelSize.height,
                           rotation);
                 }
                 else {
-                    MyLog(@"D: NSScreen #%u (%.0fx%.0f %g°) %0.2f DPI",
+                    MyLog(@"D: CGDisplay %@ dispID(#%u) (%.0fx%.0f %g°) %0.2f DPI",
+                          screenUUIDstr,
                           screenNumber,
                           displayPixelSize.width,
                           displayPixelSize.height,
@@ -340,14 +344,50 @@ int main(int argc, const char * argv[])
             }
         }
 
+        // get the WindowServer's table of DisplayIds -> IODisplays
+        NSString *wsPrefs = @"/Library/Preferences/com.apple.windowserver.plist";
+        NSDictionary *wsDict = [NSDictionary dictionaryWithContentsOfFile:wsPrefs];
+        if (!wsDict)
+            MyLog(@"E: Failed to parse WindowServer's preferences! (%@)", wsPrefs);
+        NSArray *wsDisplaySets = [wsDict valueForKey:@"DisplayAnyUserSets"];
+        if (!wsDisplaySets)
+            MyLog(@"E: Failed to get 'DisplayAnyUserSets' key from WindowServer's preferences! (%@)", wsPrefs);
 
         // Let's go...
         if (0 < displayId && displayId <= [_displayIDs count]) {
-            MyLog(@"I: polling display %lu's EDID", displayId);
             CGDirectDisplayID cdisplay = (CGDirectDisplayID)[_displayIDs pointerAtIndex:displayId - 1];
+
+            NSString *devLoc;
+	        // $ PlistBuddy -c "Print DisplayAnyUserSets:0:0:IODisplayLocation" -c "Print DisplayAnyUserSets:0:0:DisplayID" /Library/Preferences/com.apple.windowserver.plist
+	        // > IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/PEG0@1/IOPP/GFX0@0/ATY,Longavi@0/AMDFramebufferVIB
+	        // > 69733382
+            for (NSArray *displaySet in wsDisplaySets) {
+                for (NSDictionary *display in displaySet) {
+                    if ([[display valueForKey:@"DisplayID"] integerValue] == cdisplay) {
+                        devLoc = [display valueForKey:@"IODisplayLocation"]; // kIODisplayLocationKey
+                        break;
+                    }
+                }
+            }
+
+            if (!devLoc) {
+                MyLog(@"E: Failed to find display in WindowServer's preferences! (%@)", wsPrefs);
+                // we can try without this info, but we're likely to confuse identical monitors' framebuffers
+            }
+
+            // grab the IOFramebuffer for the display, this is where DDC/I2C commands are sent
+            io_service_t framebuffer;
+            if (! (framebuffer = IOFramebufferPortFromCGDisplayID(cdisplay, (__bridge CFStringRef)devLoc))) {
+                // CGDisplayIOServicePort(cdisplay) // Deprecated in OSX 10.9!
+                MyLog(@"E: Failed to acquire framebuffer device for display");
+                return -1;
+            }
+
+            MyLog(@"I: polling EDID for #%lu (ID %u => %@)", displayId, cdisplay, devLoc);
+
             struct EDID edid = {};
-            if (EDIDTest(cdisplay, &edid)) {
-				for (union descriptor *des = edid.descriptors; des < edid.descriptors + sizeof(edid.descriptors) / sizeof(edid.descriptors[0]); des++) {
+            if (EDIDTest(framebuffer, &edid)) {
+                for (union descriptor *des = edid.descriptors; des < edid.descriptors + sizeof(edid.descriptors) / sizeof(edid.descriptors[0]); des++) {
                     switch (des->text.type)
                     {
                         case 0xFF:
@@ -359,44 +399,47 @@ int main(int argc, const char * argv[])
                             break;
                     }
                 }
-
-                // Debugging
-                if (dump_values) {
-                    for (uint i=0x00; i<=255; i++) {
-                        getControl(cdisplay, i);
-                        usleep(command_interval);
-                    }
-                }
-
-                // Actions
-                [actions enumerateKeysAndObjectsUsingBlock:^(id argname, NSArray* valueArray, BOOL *stop) {
-                    NSInteger control_id = [valueArray[0] intValue];
-                    NSString *argval = valueArray[1];
-                    MyLog(@"D: action: %@: %@", argname, argval);
-
-                    if (control_id > -1) {
-                        // this is a valid monitor control
-                        NSString *argval_num = [argval stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"-+"]]; // look for relative setting ops
-                        if ([argval hasPrefix:@"+"] || [argval hasPrefix:@"-"]) { // +/-NN relative
-                            getSetControl(cdisplay, control_id, argval_num, [argval substringToIndex:1]);
-                        } else if ([argval hasSuffix:@"+"] || [argval hasSuffix:@"-"]) { // NN+/- relative
-                            // read, calculate, then write
-                            getSetControl(cdisplay, control_id, argval_num, [argval substringFromIndex:argval.length - 1]);
-                        } else if ([argval hasPrefix:@"?"]) {
-                            // read current setting
-                            getControl(cdisplay, control_id);
-                        } else if (argval_num == argval) {
-                            // write fixed setting
-                            setControl(cdisplay, control_id, [argval intValue]);
-                        }
-                    }
-                    usleep(command_interval); // stagger comms to these wimpy I2C mcu's
-                }];
-
             } else {
                 MyLog(@"E: Failed to poll display!");
+                IOObjectRelease(framebuffer);
                 return -1;
             }
+
+            // Debugging
+            if (dump_values) {
+                for (uint i=0x00; i<=255; i++) {
+                    getControl(framebuffer, i);
+                    usleep(command_interval);
+                }
+            }
+
+            // Actions
+            [actions enumerateKeysAndObjectsUsingBlock:^(id argname, NSArray* valueArray, BOOL *stop) {
+                NSInteger control_id = [valueArray[0] intValue];
+                NSString *argval = valueArray[1];
+                MyLog(@"D: action: %@: %@", argname, argval);
+
+                if (control_id > -1) {
+                    // this is a valid monitor control
+                    NSString *argval_num = [argval stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"-+"]]; // look for relative setting ops
+                    if ([argval hasPrefix:@"+"] || [argval hasPrefix:@"-"]) { // +/-NN relative
+                        getSetControl(framebuffer, control_id, argval_num, [argval substringToIndex:1]);
+                    } else if ([argval hasSuffix:@"+"] || [argval hasSuffix:@"-"]) { // NN+/- relative
+                        // read, calculate, then write
+                        getSetControl(framebuffer, control_id, argval_num, [argval substringFromIndex:argval.length - 1]);
+                    } else if ([argval hasPrefix:@"?"]) {
+                        // read current setting
+                        getControl(framebuffer, control_id);
+                    } else if (argval_num == argval) {
+                        // write fixed setting
+                        setControl(framebuffer, control_id, [argval intValue]);
+                    }
+                }
+                usleep(command_interval); // stagger comms to these wimpy I2C mcu's
+            }];
+
+            // done with all actions, release display's framebuffer
+            IOObjectRelease(framebuffer);
         } else { // no display id given
             NSLog(@"%@", HelpString);
         }

--- a/src/ddcctl.m
+++ b/src/ddcctl.m
@@ -39,6 +39,11 @@ NSString *EDIDString(char *string)
 
 NSString *getDisplayDeviceLocation(CGDirectDisplayID cdisplay)
 {
+    // FIXME: scraping prefs files is vulnerable to use of stale data?
+    // TODO: try shelling `system_profiler SPDisplaysDataType -xml` to get "_spdisplays_displayPath" keys
+    //    this seems to use private routines in:
+    //      /System/Library/SystemProfiler/SPDisplaysReporter.spreporter/Contents/MacOS/SPDisplaysReporter
+
     // get the WindowServer's table of DisplayIds -> IODisplays
     NSString *wsPrefs = @"/Library/Preferences/com.apple.windowserver.plist";
     NSDictionary *wsDict = [NSDictionary dictionaryWithContentsOfFile:wsPrefs];


### PR DESCRIPTION
fix #17, by partially reverting 0d660108 and only falling back to the "replacement" for the [deprecated](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGDisplayIOServicePort) `CGDisplayIOServicePort` API function _if_ it ever disappears from the OS libraries _for reals_ or is nerfed.

the fallback function is refined to use some helper information grabbed from WindowServer.plist so it might be able to discern frame buffers of identical monitor model's apart, based on their IOReg locations as recorded in the prefs file. This file does seem to take a few seconds to update after a monitor is first plugged into a system, so I'm hoping to find a better way to get this information in the future.

I'm still not in possession of two matched monitors so I can't really test that #17 is fixed, but it works for my usual setups (Intel and AMD)