### PR TITLE
Build error fixes and example script state file supporting poor firmwares

### DIFF
--- a/scripts/ddcctl.sh
+++ b/scripts/ddcctl.sh
@@ -2,33 +2,103 @@
 #tweak OSX display monitors' brightness to a given scheme, increment, or based on the current local time
 
 hp="ddcctl -d 1"
-len="ddcctl -d 2"
+#len="ddcctl -d 2"
+
+poweroff() {
+    # Power button will need pressing to power back on
+    $hp -p 5
+}
+
+volmute() {
+    # Set volume to 0 / mute
+    newvol=0
+    volume=$newvol
+    $hp -v $newvol
+}
+
+voldown() {
+    # Decrement the volume by one
+    newvol=$((volume-1))
+    # But dont be negative
+    [[ $newvol -lt 0 ]] && newvol=0
+    volume=$newvol
+    $hp -v $newvol
+}
+
+volup() {
+    # Increment the volume by one
+    newvol=$((volume+1))
+    # But cap at 30 so we dont damage anything
+    [[ $newvol -gt 30 ]] && newvol=30
+    volume=$newvol
+    $hp -v $volume
+}
 
 dim() {
-	$hp -b 42 -c 26
-	$len -b 4 -c 9
+    $hp -b 42 -c 26
+    #$len -b 4 -c 9
 }
 
 bright() {
-	$hp -b 100 -c 75
-	$len -b 85 -c 80
+    $hp -b 100 -c 75
+    #$len -b 85 -c 80
 }
 
 up() {
-	$hp -b 20+ -c 12+
-	$len -b 15+ -c 12+
+    newb=$((brightness+10))
+    [[ $newb -gt 100 ]] && newb=100
+    brightness=$newb
+    $hp -b $brightness -c 12+
+    #$len -b $brightness -c 12+
 }
 
 down() {
-	$hp -b 20- -c 12-
-	$len -b 15- -c 12-
+    newb=$((brightness-10))
+    [[ $newb -lt 0 ]] && newb=0
+    brightness=$newb
+    $hp -b $brightness -c 12-
+    #$len -b 20- -c 12-
+}
+
+init() {
+    state_file="$HOME/.ddc_control_state"
+    if [[ ! -f $state_file ]]; then
+        echo "Creating a new state file... ($state_file)"
+        touch "$state_file" || exit 1
+    else
+        echo "Reading state file... ($state_file)"
+        # shellcheck source=/dev/null
+        source "$state_file"
+    fi
+
+    if [[ -z "$volume" ]]; then
+        volume=5
+        echo "No state [volume]     (setting to $volume)"
+    elif [[ -z "$brightness" ]]; then
+        brightness=42
+        echo "No state [brightness] (setting to $brightness)"
+    elif [[ -z "$contrast" ]]; then
+        contrast=70
+        echo "No state [contrast]   (setting to $contrast)"
+    fi
+}
+
+savestate() {
+    echo "Saving state to file..."
+    cat <<EOF > "$state_file"
+export volume=$volume
+export brightness=$brightness
+export contrast=$contrast
+EOF
 }
 
 case "$1" in
-	dim|bright|up|down) $1;;
-	*)	#no scheme given, match local Hour of Day
-		HoD=$(date +%k) #hour of day
-		let "night = (( $HoD < 7 || $HoD > 18 ))" #daytime is 7a-7p
-		(($night)) && dim || bright
-		;;
+    dim|bright|up|down) init; $1; savestate;;
+    volmute) init; $1;;
+    voldown|volup) init; $1; savestate;;
+    *)  #no scheme given, match local Hour of Day
+        #HoD=$(date +%k) #hour of day
+        #let "night = (( $HoD < 7 || $HoD > 18 ))" #daytime is 7a-7p
+        #(($night)) && dim || bright
+        ;;
 esac

--- a/scripts/ddcctl.sh
+++ b/scripts/ddcctl.sh
@@ -96,6 +96,7 @@ case "$1" in
     dim|bright|up|down) init; $1; savestate;;
     volmute) init; $1;;
     voldown|volup) init; $1; savestate;;
+    poweroff) init; $1;;
     *)  #no scheme given, match local Hour of Day
         #HoD=$(date +%k) #hour of day
         #let "night = (( $HoD < 7 || $HoD > 18 ))" #daytime is 7a-7p

--- a/scripts/ddcctl.sh
+++ b/scripts/ddcctl.sh
@@ -104,8 +104,8 @@ case "$1" in
     voldown|volup) init; $1; savestate;;
     poweroff) init; $1;;
     *)  #no scheme given, match local Hour of Day
-        #HoD=$(date +%k) #hour of day
-        #let "night = (( $HoD < 7 || $HoD > 18 ))" #daytime is 7a-7p
-        #(($night)) && dim || bright
+        HoD=$(date +%k) #hour of day
+        let "night = (( $HoD < 7 || $HoD > 18 ))" #daytime is 7a-7p
+        (($night)) && dim || bright
         ;;
 esac

--- a/scripts/ddcctl.sh
+++ b/scripts/ddcctl.sh
@@ -2,7 +2,7 @@
 #tweak OSX display monitors' brightness to a given scheme, increment, or based on the current local time
 
 hp="ddcctl -d 1"
-#len="ddcctl -d 2"
+len="ddcctl -d 2"
 
 poweroff() {
     # Power button will need pressing to power back on
@@ -36,28 +36,34 @@ volup() {
 
 dim() {
     $hp -b 42 -c 26
-    #$len -b 4 -c 9
+    $len -b 4 -c 9
 }
 
 bright() {
     $hp -b 100 -c 75
-    #$len -b 85 -c 80
+    $len -b 85 -c 80
 }
 
 up() {
     newb=$((brightness+10))
+    newc=$((contrast+10))
     [[ $newb -gt 100 ]] && newb=100
+    [[ $newc -gt 100 ]] && newc=100
     brightness=$newb
-    $hp -b $brightness -c 12+
-    #$len -b $brightness -c 12+
+    contrast=$newc
+    $hp -b $brightness -c $contrast
+    $len -b $brightness -c $contrast
 }
 
 down() {
     newb=$((brightness-10))
+    newc=$((contrast-10))
     [[ $newb -lt 0 ]] && newb=0
+    [[ $newc -lt 0 ]] && newc=0
     brightness=$newb
-    $hp -b $brightness -c 12-
-    #$len -b 20- -c 12-
+    contrast=$newc
+    $hp -b $brightness -c $contrast
+    $len -b $brightness -c $contrast
 }
 
 init() {

--- a/src/DDC.h
+++ b/src/DDC.h
@@ -12,6 +12,9 @@
 #define DDC_Panel_DDC_h
 
 #include <IOKit/i2c/IOI2CInterface.h>
+#include <CoreGraphics/CGDirectDisplay.h>
+#include <CoreGraphics/CGDisplayConfiguration.h>
+#include <ColorSync/ColorSyncDevice.h>
 
 #define RESET 0x04
 #define RESET_BRIGHTNESS_AND_CONTRAST 0x05

--- a/src/ddcctl.m
+++ b/src/ddcctl.m
@@ -31,7 +31,7 @@ bool useOsd;
 
 extern io_service_t CGDisplayIOServicePort(CGDirectDisplayID display) __attribute__((weak_import));
 
-extern long DDCDelayBase;
+long DDCDelayBase;
 
 NSString *EDIDString(char *string)
 {


### PR DESCRIPTION
- Added some missing frameworks to the DDC.h which Xcode 13.0 complained about.
- Avoid the 'duplicate symbol' linking error (for _DDCDelayBase) which Xcode 13.0 complained about. 
- Changes to the example script :
    - Added a state file to the example script; maintaining brightness, contrast and volume settings for monitor firmwares lacking support for relative adjustments.
    - Added a poweroff option